### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -7,6 +7,8 @@
 # documentation.
 
 name: Java CI with Maven
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/lelsaesser/tradebot/security/code-scanning/1](https://github.com/lelsaesser/tradebot/security/code-scanning/1)

To fix the issue, add a `permissions` block to the root of the workflow file. This block will explicitly limit the permissions of the `GITHUB_TOKEN` to the least privileges required for the workflow. Based on the provided steps, the workflow only needs read access to the repository contents. Therefore, the `permissions` block should be set to `contents: read`.

The change should be made at the root level of the workflow file, immediately after the `name` field, to apply the permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
