### PR TITLE
hotfix - prevent bad message process deadlock

### DIFF
--- a/src/main/java/org/tradelite/client/telegram/TelegramMessageProcessor.java
+++ b/src/main/java/org/tradelite/client/telegram/TelegramMessageProcessor.java
@@ -43,10 +43,12 @@ public class TelegramMessageProcessor {
                 continue;
             }
 
-            Optional<TelegramCommand> command = parseMessage(chatUpdate);
-            command.ifPresent(telegramCommandDispatcher::dispatch);
-
-            telegramMessageTracker.setLastProcessedMessageId(messageId);
+            try {
+                Optional<TelegramCommand> command = parseMessage(chatUpdate);
+                command.ifPresent(telegramCommandDispatcher::dispatch);
+            } finally {
+                telegramMessageTracker.setLastProcessedMessageId(messageId);
+            }
         }
     }
 


### PR DESCRIPTION
always mark processed messages as processed, even if processing failed (exception occurred).

otherwise we run into a deadlock, where the same message is attempted to be processed over an over again.