### PR TITLE
Move Telegram message API parameters to payload

### DIFF
--- a/src/main/java/org/tradelite/client/telegram/TelegramClient.java
+++ b/src/main/java/org/tradelite/client/telegram/TelegramClient.java
@@ -16,8 +16,7 @@ import org.tradelite.client.telegram.dto.TelegramUpdateResponseWrapper;
 @Component
 public class TelegramClient {
 
-    protected static final String BASE_URL =
-            "https://api.telegram.org/bot%s/sendMessage?chat_id=%s&text=%s";
+    protected static final String BASE_URL = "https://api.telegram.org/bot%s/sendMessage";
 
     private final RestTemplate restTemplate;
     private final String botToken;
@@ -34,9 +33,11 @@ public class TelegramClient {
     }
 
     public void sendMessage(String message) {
-        String url = String.format(BASE_URL, botToken, groupChatId, message);
+        String url = String.format(BASE_URL, botToken);
 
         Map<String, Object> payload = new HashMap<>();
+        payload.put("chat_id", groupChatId);
+        payload.put("text", message);
         payload.put("parse_mode", "Markdown");
 
         HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/org/tradelite/common/StockSymbol.java
+++ b/src/main/java/org/tradelite/common/StockSymbol.java
@@ -7,8 +7,6 @@ import lombok.Getter;
 
 @Getter
 public enum StockSymbol implements TickerSymbol {
-    // do not add special characters to the names, this causes parsing issues with the Telegram
-    // messages for some reason
     AAPL("Apple", "AAPL"),
     MSFT("Microsoft", "MSFT"),
     GOOG("Google", "GOOG"),


### PR DESCRIPTION
... instead of using URL parameters. 
URL parameters caused multiple issues depending on the message contents due to URL encoding.

Examples:

- Sock names which included special characters: Hims & Hers, the "&" char was misinterpreted.
- "+" sign in the RSI difference message was misinterpreted.
