### PR TITLE
Add sector RS report evening execution

### DIFF
--- a/src/main/java/org/tradelite/Scheduler.java
+++ b/src/main/java/org/tradelite/Scheduler.java
@@ -118,7 +118,7 @@ public class Scheduler {
         log.info("Relative strength vs SPY analysis completed.");
     }
 
-    @Scheduled(cron = "0 0 16 * * MON-FRI", zone = "CET")
+    @Scheduled(cron = "0 0 16,21 * * MON-FRI", zone = "CET")
     protected void dailySectorRelativeStrengthReport() {
         rootErrorHandler.run(sectorRelativeStrengthTracker::sendDailySectorRsSummary);
         log.info("Daily sector relative strength report completed.");


### PR DESCRIPTION
A single cron expression handles both times — no need for two separate jobs. 

Changed the `@Scheduled` annotation on `dailySectorRelativeStrengthReport()` from:

```
@Scheduled(cron = "0 0 16 * * MON-FRI", zone = "CET")
```

to:

```
@Scheduled(cron = "0 0 16,21 * * MON-FRI", zone = "CET")
```

Spring's cron syntax supports comma-separated values in the hour field, so `16,21` fires the job at both 16:00 and 21:00 CET on weekdays.